### PR TITLE
7-data-retrieval: moved `zone-depth` definition/response to a separate

### DIFF
--- a/core/requirements/data-retrieval/REQ_data-retrieval_single-zone-data-op.adoc
+++ b/core/requirements/data-retrieval/REQ_data-retrieval_single-zone-data-op.adoc
@@ -1,15 +1,13 @@
+[[req_data-retrieval_single-zone-data-op]]
+
 [requirement]
 ====
 [%metadata]
 label:: /req/data-retrieval/single-zone-data-op
-description:: For retrieving data for a single DGGS zone:
-part:: The Implementation SHALL support an HTTP GET operation at a resource path
+description:: Operation for retrieving data from a single DGGS zone:
+part:: The operation SHALL support an HTTP GET operation at a resource path
 ending with `.../dggs/{dggsId}/zones/{zoneId}/data`.
-part:: The implementation SHALL support a `zone-depth` parameter indicating the resolution levels
-beyond the current zone's hierarchy level at which to retrieve the data. This `zone-depth` parameter
-can be either a single integer value, a range of values in the form `{low}-{high}`, or a comma-separated
-list of depths to be included.
-A `zone-depth` of 0 corresponds to a single set of range (properties / field values) values for the requested zone.
-part:: The Implementation SHALL provide a templated  link to this resource path using
+part:: The operation SHALL satisfy requirement <<req_data-retrieval_zone-depth-definition,/req/data-retrieval/rc-zone-depth-definition>>.
+part:: The operation SHALL provide a templated  link to this resource path using
 the link relation type http://www.opengis.net/def/rel/ogc/1.0/dggs-zone-data.
 ====

--- a/core/requirements/data-retrieval/REQ_data-retrieval_single-zone-data-response.adoc
+++ b/core/requirements/data-retrieval/REQ_data-retrieval_single-zone-data-response.adoc
@@ -1,3 +1,5 @@
+[[req_data-retrieval_single-zone-data-response]]
+
 [requirement]
 ====
 [%metadata]
@@ -6,20 +8,7 @@ description:: For the response to a query retrieving data for a single DGGS zone
 part:: The response of the HTTP GET operation SHALL have a status code of 200.
 part:: The content of the response SHALL be a data packet corresponding precisely to the area
 covered by the DGGS zone.
-part:: If a `zone-depth` is specified, the implementation SHALL return the data at the resolution / scale specified
-by the `zone-depth` parameter, in accordance to the capabilities of the data packet encoding.
-The data encoding may support a fixed depth, a range of depth, and/or an arbitrary selection of depths.
-part:: If the `zone-depth` parameter is omitted, a default zone depth SHALL be assumed corresponding
-to that specified by the data packet encoding, or if none is specified by the data encoding, to the one specified
-by the DGGS Reference System, or if none is specified by the DGGS Reference System, to 0.
+part:: The response SHALL satisfy requirement <<req_data-retrieval_zone-depth-response,/req/data-retrieval/rc-zone-depth-response>>.
 part:: The selection of an encoding for the response SHALL be consistent with HTTP content negotiation.
 ====
 
-NOTE: A use case for a `zone-depth` of 0 would be to query the single set values for a specific zone.
-
-NOTE: For use cases such as visualization and performing analysis over a certain area,
-a non-zero `zone-depth` would normally be used to avoid an overwhelming number of server round-trips.
-In this case, more than a single value would be returned for each zone request,
-with values returned for descendent zones at `zone-depth` levels deeper than the requested zone's level.
-For example, requesting data for a level 10 zone with a `zone-depth` of 8 would return
-individual values for each level 18 zones contained within that level 10 zone being requested.

--- a/core/requirements/data-retrieval/REQ_parameter_zone_depth_definition.adoc
+++ b/core/requirements/data-retrieval/REQ_parameter_zone_depth_definition.adoc
@@ -1,0 +1,53 @@
+[[req_data-retrieval_zone-depth-definition]]
+
+[requirement]
+====
+[%metadata]
+label:: /req/data-retrieval/rc-zone-depth-definition
+description:: Parameter to specify the DGGS resolution levels to request data from beyond the requested zone's hierarchy level.
+part:: The HTTP GET operation on a resource path
+ending with `.../dggs/{dggsId}/zones/{zoneId}/data` SHALL support a parameter `zone-depth.
+
+part:: The `zone-depth` parameter specifies the DGGS resolution levels beyond the requested zone's hierarchy level from which to retrieve data.
+The zone-depth can be either:
+
+* A single positive integer value - representing a specific `zone-level` to return (e.g. zone-depth=5);
+
+* A range of positive integer values in the form "{low}-{high}" - representing a continuous range of `zone-levels` to return (e.g. zone-depth=1-8); or,
+
+* A comma separated list of at least two (2) positive integer values - representing a set of specific `zone-levels` to return (e.g. zone-depth=1,3,7).  
+part:: A `zone-depth` of 0 (e.g. zone-depth=0) corresponds to a single value, or a set of single values, (properties / field values) for the requested zone.
+
+part:: The parameter `zone-depth` SHALL have the following characteristics (using an OpenAPI Specification 3.0 fragment):
+[source,YAML]
+----
+name: zone-depth
+in: query
+description: |-
+  This parameter specifies the DGGS resolution levels beyond to requested zone's hierarchy level from which to retrieve data.
+  The zone-depth can be either:
+  
+  * A single positive integer value - representing a specific `zone-level` to return (e.g. zone-depth=5);
+  
+  * A range of positive integer values in the form "{low}-{high}" - representing a continuous range of `zone-levels` to return (e.g. zone-depth=1-8); or,
+  
+  * A comma separated list of at least two (2) positive integer values - representing a set of specific `zone-levels` to return (e.g. zone-depth=1,3,7).  
+required: false
+schema:
+  oneOf:
+  	- type: integer
+  	  minimum: 0
+  	- type: string
+  	- type: array
+  	  items:
+  	    minItems: 2
+  	    type: integer
+  	    minimum: 0
+  default: 0
+style: form
+----
+
+
+NOTE: The `default` value in the schema can be set to any valid value and/or form defined above and in accordance with the DGGS data mapping approach deployed by the server.
+
+====

--- a/core/requirements/data-retrieval/REQ_parameter_zone_depth_response.adoc
+++ b/core/requirements/data-retrieval/REQ_parameter_zone_depth_response.adoc
@@ -1,0 +1,23 @@
+[[req_data-retrieval_zone-depth-response]]
+
+[requirement]
+====
+[%metadata]
+label:: /req/data-retrieval/rc-zone-depth-response
+description:: Response requirements for the Parameter specifying the DGGS resolution levels to request data from beyond the requested zone's hierarchy level.
+part:: If a `zone-depth` is specified, the operation SHALL return the data at the resolution / scale specified
+by the `zone-depth` parameter, in accordance to the capabilities of the data packet encoding.
+part:: The data encoding may support a fixed depth, a range of depths, and/or an arbitrary selection of depths.
+part:: If the `zone-depth` parameter is omitted, the `default` value in the schema of `zone-depth` SHALL be assumed by the server, in accordance to the capabilities of the data packet encoding.
+
+
+NOTE: A use case for a `zone-depth` of 0 would be to query the single set of values for a specific DGGS zone.
+
+NOTE: For use cases such as visualization and performing analysis over a certain area,
+a non-zero `zone-depth` would normally be used to avoid an overwhelming number of server round-trips.
+In this case, more than a single value would be returned for each zone request,
+with values returned for descendent zones at `zone-depth` levels deeper than the requested zone's level.
+For example, requesting data for a level 10 zone with a `zone-depth` of 8 would return
+individual values for each level 18 zones contained within that level 10 zone being requested.
+
+====

--- a/core/sections/clause_7_dggs_data_retrieval.adoc
+++ b/core/sections/clause_7_dggs_data_retrieval.adoc
@@ -21,6 +21,10 @@ include::../requirements/requirements_class_data-retrieval.adoc[]
 The following requirements describe how a client can retrieve data from a single DGGS zone
 at the resource path `.../dggs/{dggsId}/zones/{zoneId}/data`.
 
+==== Parameter zone-depth
+include::../requirements/data-retrieval/REQ_parameter_zone_depth_definition.adoc[]
+include::../requirements/data-retrieval/REQ_parameter_zone_depth_response.adoc[]
+
 ==== Operation
 
 include::../requirements/data-retrieval/REQ_data-retrieval_single-zone-data-op.adoc[]
@@ -28,3 +32,7 @@ include::../requirements/data-retrieval/REQ_data-retrieval_single-zone-data-op.a
 ==== Response
 
 include::../requirements/data-retrieval/REQ_data-retrieval_single-zone-data-response.adoc[]
+
+
+
+


### PR DESCRIPTION
requirement class: 7-data-retrieval - zone-depth parameter

A suggestion to solving the `default` value issue with `zone-depth` parameter.

1. Following the OGC API Features - Part 3 approach to the `filter-lang` query parameter - where the parameter is formally defined in the OpenAPI Definition schema - with a `default` value specified by the implementer of the API. If the parameter is omitted then the schema defined `default` value is assumed.
2. Followed the example of the `bbox` parameter to define a parameter schema for `zone-depth` that caters for either:
    - A single depth value (e.g. zone-depth=5);
    - A continuous range of depth values (e.g. zone-depth=2-8); or,
    - A defined list of specific depth values (e.g. zone-depth=0,3,4,7,8).
 
Because in this suggested change we're defining a specific schema for the parameter (and there are now quite a number of requirements for the 'definition' and 'response' for that parameter) I've created a separate set of requirements for the `zone-depth` parameter and linked that to the `data retrieval` operation and response requirements rather than just having it all in the original requirement classes.